### PR TITLE
Fix getToken range check and clean examples

### DIFF
--- a/examples/example1.js
+++ b/examples/example1.js
@@ -4,5 +4,4 @@ let befunge = new Befunge();
 
 befunge.run("1234v\n>9 #5>:#._@\n^876<")
     .then((output) => {
-        console.log(output);
-    });
+        console.log(output);    });

--- a/examples/example2.js
+++ b/examples/example2.js
@@ -26,5 +26,4 @@ befunge.onStackChange = (stack) => {
 
 befunge.run("1123v\n>89#4>:#._@\n^765<")
     .then((output) => {
-        console.log(output);
-    });
+        console.log(output);    });

--- a/lib/befunge93.js
+++ b/lib/befunge93.js
@@ -460,7 +460,7 @@ class Befunge93 {
 
     /** @private */
     getToken(x, y) {
-        if (!(0 <= x < 80) || !(0 <= y < 25)) {
+        if (!(0 <= x && x < 80) || !(0 <= y && y < 25)) {
             throw new Error("Coordinates out of range!");
         }
         return this.program[y][x];


### PR DESCRIPTION
## Summary
- fix range check in `getToken`
- clean up example scripts

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ee256357c8331841c8756f83ab062