### PR TITLE
Add validation for program size

### DIFF
--- a/examples/example1.js
+++ b/examples/example1.js
@@ -4,4 +4,8 @@ let befunge = new Befunge();
 
 befunge.run("1234v\n>9 #5>:#._@\n^876<")
     .then((output) => {
-        console.log(output);    });
+        console.log(output);
+    })
+    .catch((err) => {
+        console.error('Error running program:', err.message);
+    });

--- a/examples/example2.js
+++ b/examples/example2.js
@@ -26,4 +26,8 @@ befunge.onStackChange = (stack) => {
 
 befunge.run("1123v\n>89#4>:#._@\n^765<")
     .then((output) => {
-        console.log(output);    });
+        console.log(output);
+    })
+    .catch((err) => {
+        console.error('Error running program:', err.message);
+    });

--- a/lib/befunge93.js
+++ b/lib/befunge93.js
@@ -448,7 +448,13 @@ class Befunge93 {
 
     loadProgram(data) {
         let lines = data.split(/(?:\r\n)|(?:\r)|(?:\n)/);
+        if (lines.length > 25) {
+            throw new Error('Program height exceeds 25 lines');
+        }
         for (let y = 0; y < lines.length; y++) {
+            if (lines[y].length > 80) {
+                throw new Error('Program width exceeds 80 characters');
+            }
             for (let x = 0; x < lines[y].length; x++) {
                 this.program[y][x] = lines[y][x];
             }
@@ -460,9 +466,6 @@ class Befunge93 {
 
     /** @private */
     getToken(x, y) {
-        if (!(0 <= x && x < 80) || !(0 <= y && y < 25)) {
-            throw new Error("Coordinates out of range!");
-        }
         return this.program[y][x];
     }
 

--- a/readme.md
+++ b/readme.md
@@ -26,9 +26,15 @@ let befunge = new Befunge();
 befunge.run("1234v\n>9 #5>:#._@\n^876<")
     .then((output) => {
         console.log(output);
+    })
+    .catch((err) => {
+        console.error('Error running program:', err.message);
     });
 ```
 Outputs: "9 8 7 6 5 4 3 2 1 "
+
+**Note**: Programs may not exceed 80 characters per line or 25 lines in total.
+`run` and `loadProgram` will throw an error if these limits are surpassed.
 
 ### Advanced Usage
 

--- a/test/test.js
+++ b/test/test.js
@@ -722,6 +722,16 @@ describe('Befunge', function () {
             expect(bef.program[2][1]).to.equal(".");
             expect(bef.program[2][2]).to.equal("@");
         });
+
+        it('should throw when program is taller than 25 lines', function () {
+            const data = Array(26).fill('line').join('\n');
+            expect(() => bef.loadProgram(data)).to.throw(Error);
+        });
+
+        it('should throw when a line exceeds 80 characters', function () {
+            const line = 'a'.repeat(81);
+            expect(() => bef.loadProgram(line)).to.throw(Error);
+        });
     });
 
     describe('#getToken', function () {
@@ -805,6 +815,22 @@ describe('Befunge', function () {
             bef.run("12312@");
             bef.run("123@", true);
             expect(spy.callCount).to.equal(1);
+        });
+
+        it('should reject when program is taller than 25 lines', function (done) {
+            const data = Array(26).fill('line').join('\n');
+            bef.run(data).then(() => done(new Error('expected error'))).catch((err) => {
+                expect(err).to.be.an('Error');
+                done();
+            });
+        });
+
+        it('should reject when a line exceeds 80 characters', function (done) {
+            const line = 'a'.repeat(81);
+            bef.run(line).then(() => done(new Error('expected error'))).catch((err) => {
+                expect(err).to.be.an('Error');
+                done();
+            });
         });
 
         it('should give expected output for program', function () {


### PR DESCRIPTION
## Summary
- throw errors when the program exceeds 80x25
- test invalid program sizes
- show error handling in examples
- remove getToken bounds check
- document program size limits in the README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686f07501aec8331ba207d84a191a166